### PR TITLE
Revert "Bump actions/checkout from 3 to 4"

### DIFF
--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       workflows: ${{ steps.changes.outputs.workflows }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
         id: changes
         with:


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #nnn

## Why was change needed

???

## What does change improve

???
