### PR TITLE
Add optional additional-info input to slack notification workflow

### DIFF
--- a/.github/workflows/build-failure-slack-notification.yaml
+++ b/.github/workflows/build-failure-slack-notification.yaml
@@ -11,6 +11,10 @@ on:
       job-status:
         required: true
         type: string
+      additional-info:
+        required: false
+        type: string
+        default: ""
 
 permissions: {}
 
@@ -38,8 +42,8 @@ jobs:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "_*REPO:*_ `${{ github.repository }}` _*BRANCH:*_ `${{ env.BRANCH_NAME }}` workflow ${{ inputs.job-status }} <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"
+                  text: "_*REPO:*_ `${{ github.repository }}` _*BRANCH:*_ `${{ env.BRANCH_NAME }}` workflow ${{ inputs.job-status }} <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>${{ inputs.additional-info != '' && format(' | {0}', inputs.additional-info) || '' }}"
             channel: "${{ secrets.SLACK_CHANNEL }}"
-            text: "_*REPO:*_ `${{ github.repository }}` _*BRANCH:*_ `${{ env.BRANCH_NAME }}` workflow ${{ inputs.job-status }} <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"
+            text: "_*REPO:*_ `${{ github.repository }}` _*BRANCH:*_ `${{ env.BRANCH_NAME }}` workflow ${{ inputs.job-status }} <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>${{ inputs.additional-info != '' && format(' | {0}', inputs.additional-info) || '' }}"
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           errors: true


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #nnn

## Why was change needed

???

## What does change improve

Allows callers to append context (e.g., SDK version from matrix) to failure notifications. Defaults to empty string so existing callers are unaffected.
