### PR TITLE
Add slack failure notification composite action

### DIFF
--- a/.github/linters/zizmor.yaml
+++ b/.github/linters/zizmor.yaml
@@ -5,6 +5,6 @@ rules:
         "*": ref-pin
   secrets-outside-env:
     ignore:
-      - .github/workflows/add-to-project.yaml
-      - .github/workflows/add-labels-to-issue.yaml
-      - .github/workflows/add-to-project-dependabot.yaml
+      - add-to-project.yaml
+      - add-labels-to-issue.yaml
+      - add-to-project-dependabot.yaml

--- a/.github/linters/zizmor.yaml
+++ b/.github/linters/zizmor.yaml
@@ -3,3 +3,8 @@ rules:
     config:
       policies:
         "*": ref-pin
+  secrets-outside-env:
+    ignore:
+      - .github/workflows/add-to-project.yaml
+      - .github/workflows/add-labels-to-issue.yaml
+      - .github/workflows/add-to-project-dependabot.yaml

--- a/.github/workflows/add-labels-to-issue.yaml
+++ b/.github/workflows/add-labels-to-issue.yaml
@@ -32,8 +32,10 @@ jobs:
           MEMBER: ${{ contains( secrets.MEMBERS, github.actor ) }}
 
       - name: Notify Slack on failure
-        if: failure() && secrets.SLACK_BOT_TOKEN != ''
+        if: failure() && env.SLACK_TOKEN != ''
         uses: senzing-factory/build-resources/slack-failure-notification@v4
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           job-status: ${{ job.status }}
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
@@ -52,8 +54,10 @@ jobs:
           add-labels: "triage"
 
       - name: Notify Slack on failure
-        if: failure() && secrets.SLACK_BOT_TOKEN != ''
+        if: failure() && env.SLACK_TOKEN != ''
         uses: senzing-factory/build-resources/slack-failure-notification@v4
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           job-status: ${{ job.status }}
           slack-channel: ${{ secrets.SLACK_CHANNEL }}

--- a/.github/workflows/add-labels-to-issue.yaml
+++ b/.github/workflows/add-labels-to-issue.yaml
@@ -20,6 +20,8 @@ jobs:
     permissions:
       issues: write
     runs-on: ubuntu-latest
+    env:
+      SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
     steps:
       - name: Add customer-submission label
@@ -34,8 +36,6 @@ jobs:
       - name: Notify Slack on failure
         if: failure() && env.SLACK_TOKEN != ''
         uses: senzing-factory/build-resources/slack-failure-notification@v4
-        env:
-          SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           job-status: ${{ job.status }}
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
@@ -46,6 +46,8 @@ jobs:
     permissions:
       issues: write
     runs-on: ubuntu-latest
+    env:
+      SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
     steps:
       - name: add triage label
@@ -56,8 +58,6 @@ jobs:
       - name: Notify Slack on failure
         if: failure() && env.SLACK_TOKEN != ''
         uses: senzing-factory/build-resources/slack-failure-notification@v4
-        env:
-          SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           job-status: ${{ job.status }}
           slack-channel: ${{ secrets.SLACK_CHANNEL }}

--- a/.github/workflows/add-labels-to-issue.yaml
+++ b/.github/workflows/add-labels-to-issue.yaml
@@ -7,6 +7,10 @@ on:
         required: false
       MEMBERS:
         required: false
+      SLACK_BOT_TOKEN:
+        required: false
+      SLACK_CHANNEL:
+        required: false
 
 permissions: {}
 
@@ -27,6 +31,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ORG_MEMBERSHIP_TOKEN || github.token }}
           MEMBER: ${{ contains( secrets.MEMBERS, github.actor ) }}
 
+      - name: Notify Slack on failure
+        if: failure() && secrets.SLACK_BOT_TOKEN != ''
+        uses: senzing-factory/build-resources/slack-failure-notification@v4
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.SLACK_CHANNEL }}
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+
   add-triage-label:
     name: add triage label
     permissions:
@@ -38,3 +50,11 @@ jobs:
         uses: andymckay/labeler@1.0.4
         with:
           add-labels: "triage"
+
+      - name: Notify Slack on failure
+        if: failure() && secrets.SLACK_BOT_TOKEN != ''
+        uses: senzing-factory/build-resources/slack-failure-notification@v4
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.SLACK_CHANNEL }}
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/add-labels-to-issue.yaml
+++ b/.github/workflows/add-labels-to-issue.yaml
@@ -21,7 +21,7 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     env:
-      SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
     steps:
       - name: Add customer-submission label
@@ -34,7 +34,7 @@ jobs:
           MEMBER: ${{ contains( secrets.MEMBERS, github.actor ) }}
 
       - name: Notify Slack on failure
-        if: failure() && env.SLACK_TOKEN != ''
+        if: (failure() || cancelled()) && env.SLACK_BOT_TOKEN != ''
         uses: senzing-factory/build-resources/slack-failure-notification@v4
         with:
           job-status: ${{ job.status }}
@@ -47,7 +47,7 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     env:
-      SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
     steps:
       - name: add triage label
@@ -56,7 +56,7 @@ jobs:
           add-labels: "triage"
 
       - name: Notify Slack on failure
-        if: failure() && env.SLACK_TOKEN != ''
+        if: (failure() || cancelled()) && env.SLACK_BOT_TOKEN != ''
         uses: senzing-factory/build-resources/slack-failure-notification@v4
         with:
           job-status: ${{ job.status }}

--- a/.github/workflows/add-to-project-dependabot.yaml
+++ b/.github/workflows/add-to-project-dependabot.yaml
@@ -10,6 +10,10 @@ on:
     secrets:
       PROJECT_RW_TOKEN:
         required: true
+      SLACK_BOT_TOKEN:
+        required: false
+      SLACK_CHANNEL:
+        required: false
 
 permissions: {}
 
@@ -20,6 +24,8 @@ jobs:
       repository-projects: write
     secrets:
       PROJECT_RW_TOKEN: ${{ secrets.PROJECT_RW_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     uses: senzing-factory/build-resources/.github/workflows/add-to-project.yaml@v4
     with:
       org: ${{ github.repository_owner }}

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -26,7 +26,7 @@ jobs:
       repository-projects: write
     runs-on: ubuntu-latest
     env:
-      SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
     steps:
       - name: add to project
@@ -36,7 +36,7 @@ jobs:
           project-url: "https://github.com/orgs/${{inputs.org}}/projects/${{inputs.project-number}}"
 
       - name: Notify Slack on failure
-        if: failure() && env.SLACK_TOKEN != ''
+        if: (failure() || cancelled()) && env.SLACK_BOT_TOKEN != ''
         uses: senzing-factory/build-resources/slack-failure-notification@v4
         with:
           job-status: ${{ job.status }}

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -34,8 +34,10 @@ jobs:
           project-url: "https://github.com/orgs/${{inputs.org}}/projects/${{inputs.project-number}}"
 
       - name: Notify Slack on failure
-        if: failure() && secrets.SLACK_BOT_TOKEN != ''
+        if: failure() && env.SLACK_TOKEN != ''
         uses: senzing-factory/build-resources/slack-failure-notification@v4
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           job-status: ${{ job.status }}
           slack-channel: ${{ secrets.SLACK_CHANNEL }}

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -25,6 +25,8 @@ jobs:
     permissions:
       repository-projects: write
     runs-on: ubuntu-latest
+    env:
+      SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
     steps:
       - name: add to project
@@ -36,8 +38,6 @@ jobs:
       - name: Notify Slack on failure
         if: failure() && env.SLACK_TOKEN != ''
         uses: senzing-factory/build-resources/slack-failure-notification@v4
-        env:
-          SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           job-status: ${{ job.status }}
           slack-channel: ${{ secrets.SLACK_CHANNEL }}

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -12,6 +12,10 @@ on:
     secrets:
       PROJECT_RW_TOKEN:
         required: false
+      SLACK_BOT_TOKEN:
+        required: false
+      SLACK_CHANNEL:
+        required: false
 
 permissions: {}
 
@@ -28,3 +32,11 @@ jobs:
         with:
           github-token: ${{ secrets.PROJECT_RW_TOKEN }}
           project-url: "https://github.com/orgs/${{inputs.org}}/projects/${{inputs.project-number}}"
+
+      - name: Notify Slack on failure
+        if: failure() && secrets.SLACK_BOT_TOKEN != ''
+        uses: senzing-factory/build-resources/slack-failure-notification@v4
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.SLACK_CHANNEL }}
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/slack-failure-notification/action.yaml
+++ b/slack-failure-notification/action.yaml
@@ -21,8 +21,8 @@ runs:
   using: composite
   steps:
     - name: Send Slack notification
-      if: ${{ always() }}
-      uses: slackapi/slack-github-action@v3
+      if: ${{ inputs.job-status == 'failure' || inputs.job-status == 'cancelled' }}
+      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
       env:
         BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       with:

--- a/slack-failure-notification/action.yaml
+++ b/slack-failure-notification/action.yaml
@@ -16,6 +16,10 @@ inputs:
     description: Optional context to append to the message (e.g., SDK version)
     required: false
     default: ""
+  branch-name:
+    description: Branch name to display in the notification
+    required: false
+    default: ${{ github.head_ref || github.ref_name }}
 
 runs:
   using: composite
@@ -23,8 +27,6 @@ runs:
     - name: Send Slack notification
       if: ${{ inputs.job-status == 'failure' || inputs.job-status == 'cancelled' }}
       uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
-      env:
-        BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       with:
         method: chat.postMessage
         payload: |
@@ -41,8 +43,8 @@ runs:
             - type: "section"
               text:
                 type: "mrkdwn"
-                text: "_*REPO:*_ `${{ github.repository }}` _*BRANCH:*_ `${{ env.BRANCH_NAME }}` workflow ${{ inputs.job-status }} <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>${{ inputs.additional-info != '' && format(' | {0}', inputs.additional-info) || '' }}"
+                text: "_*REPO:*_ `${{ github.repository }}` _*BRANCH:*_ `${{ inputs.branch-name }}` workflow ${{ inputs.job-status }} <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>${{ inputs.additional-info != '' && format(' | {0}', inputs.additional-info) || '' }}"
           channel: "${{ inputs.slack-channel }}"
-          text: "_*REPO:*_ `${{ github.repository }}` _*BRANCH:*_ `${{ env.BRANCH_NAME }}` workflow ${{ inputs.job-status }} <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>${{ inputs.additional-info != '' && format(' | {0}', inputs.additional-info) || '' }}"
+          text: "_*REPO:*_ `${{ github.repository }}` _*BRANCH:*_ `${{ inputs.branch-name }}` workflow ${{ inputs.job-status }} <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>${{ inputs.additional-info != '' && format(' | {0}', inputs.additional-info) || '' }}"
         token: ${{ inputs.slack-bot-token }}
         errors: true

--- a/slack-failure-notification/action.yaml
+++ b/slack-failure-notification/action.yaml
@@ -1,0 +1,48 @@
+name: Slack failure notification
+description: Sends a Slack notification when a job fails. Can be used as a step inside any job, including matrix jobs.
+author: support@senzing.com
+
+inputs:
+  job-status:
+    description: The status of the job (e.g., failure, cancelled)
+    required: true
+  slack-channel:
+    description: Slack channel ID to post to
+    required: true
+  slack-bot-token:
+    description: Slack bot token for authentication
+    required: true
+  additional-info:
+    description: Optional context to append to the message (e.g., SDK version)
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Send Slack notification
+      if: ${{ always() }}
+      uses: slackapi/slack-github-action@v3
+      env:
+        BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      with:
+        method: chat.postMessage
+        payload: |
+          attachments:
+            - color: "FF0000"
+              fields:
+                - title: "Status"
+                  short: true
+                  value: "${{ inputs.job-status }}"
+                - title: "Actor"
+                  short: true
+                  value: "${{ github.actor }}"
+          blocks:
+            - type: "section"
+              text:
+                type: "mrkdwn"
+                text: "_*REPO:*_ `${{ github.repository }}` _*BRANCH:*_ `${{ env.BRANCH_NAME }}` workflow ${{ inputs.job-status }} <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>${{ inputs.additional-info != '' && format(' | {0}', inputs.additional-info) || '' }}"
+          channel: "${{ inputs.slack-channel }}"
+          text: "_*REPO:*_ `${{ github.repository }}` _*BRANCH:*_ `${{ env.BRANCH_NAME }}` workflow ${{ inputs.job-status }} <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>${{ inputs.additional-info != '' && format(' | {0}', inputs.additional-info) || '' }}"
+        token: ${{ inputs.slack-bot-token }}
+        errors: true


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #nnn

## Why was change needed

???

## What does change improve

New composite action at slack-failure-notification/ that can be used as a step inside any job, including matrix jobs where it can report the specific failing matrix entry (e.g., SDK version).

Bake slack notifications into add-to-project, add-to-project-dependabot, and add-labels-to-issue reusable workflows with optional secrets for backwards compatibility. Will be made required in v5.
